### PR TITLE
Mccalluc/filter matrix fallback

### DIFF
--- a/context/app/utils/cluster.py
+++ b/context/app/utils/cluster.py
@@ -6,7 +6,7 @@ from scipy.cluster.hierarchy import leaves_list, linkage
 
 def _order_rows(dataframe, clustering):
     row_labels = dataframe.index.tolist()
-    if clustering:
+    if clustering and len(row_labels) > 1:
         rows_linkage = linkage(dataframe, 'ward')
         rows_order = leaves_list(rows_linkage).tolist()
         return [row_labels[i] for i in rows_order]

--- a/context/tests/test_cluster.py
+++ b/context/tests/test_cluster.py
@@ -21,10 +21,29 @@ class TestCluster(unittest.TestCase):
             index=['r1', 'r2', 'r3', 'r4', 'r5', 'r6']
         )
 
+    def assert_no_change(self, array):
+        dataframe = pandas.DataFrame(array)
+        clustered = cluster(
+            dataframe, skip_zero=False,
+            cluster_rows=True, cluster_cols=True)
+        self.assertEqual(clustered.as_matrix().tolist(), array)
+
+    def test_1_1(self):
+        self.assert_no_change([[1]])
+
+    def test_1_2(self):
+        self.assert_no_change([[1, 2]])
+
+    def test_2_1(self):
+        self.assert_no_change([[2, 1]])
+
+    def test_2_2(self):
+        self.assert_no_change([[1, 2], [3, 4]])
+
     def test_pass_through(self):
         clustered = cluster(
             self.dataframe, skip_zero=False,
-            cluster_rows=False, cluster_cols=False, )
+            cluster_rows=False, cluster_cols=False)
         self.assertEqual(clustered.as_matrix().tolist(), [
             [0, 4, 0, 5],
             [0, 0, 0, 0],


### PR DESCRIPTION
I noticed that when the found set goes to one, the heatmap wouldn't update. This fixes that.