### PR TITLE
remove references to virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,12 @@ optional arguments:
 ## Getting Started
 
 The best way to run the app during development is just as a Flask app.
-Check out the project, set up a virtualenv and install dependencies:
+Check out the project and install dependencies:
 ```bash
   # Requires Python3:
 $ python --version
 $ git clone https://github.com/mccalluc/heatmap-scatter-dash.git
 $ cd heatmap-scatter-dash
-  # Set up a virtualenv, and then install dependencies:
 $ pip install -r context/requirements.txt
 ```
 


### PR DESCRIPTION
After talking with Geoff, if someone needs virtual env, they will know to use it, and if they do not, it is a distraction. Do you agree?