### PR TITLE
Mccalluc/bootstrap fullwidth

### DIFF
--- a/context/app/help/help_app.py
+++ b/context/app/help/help_app.py
@@ -32,7 +32,7 @@ class HelpApp(ResourceLoader):
                     markdown
                 ], className='col-md-12'),
             ], className='row'),
-        ], className='container')
+        ], className='container-fluid')
 
 
 def relative_path(file):

--- a/context/app/static/extra.css
+++ b/context/app/static/extra.css
@@ -1,11 +1,15 @@
 .plotlyjsicon {
+	/* We give props in other ways: having it on every hover is excessive. */
 	display: none;
 }
+
 iframe {
 	border: none;
 	width: 100%;
 	height: 33vh;
 }
+
+/* Clean, minimal table style: */
 table {
 	border: none;
 }
@@ -13,18 +17,18 @@ td, th {
 	border: none;
 	padding: 0 5px;
 }
+
+/* Bring baseline of button closer to that of the text, and space btween buttons. */
+.nav-tabs > .btn {
+	margin: 5px 0 0 5px;
+}
+
+/* Hide the "X" on pulldowns */
 .Select-clear-zone {
 	display: none;
 }
-@keyframes fadein {
-	0% {
-		opacity: 0;
-	}
-	100% {
-		opacity: 0.5;
-	}
-}
 
+/* "Please Wait" overlay */
 ._dash-loading-callback {
 	position: absolute;
 	top: 0;
@@ -35,4 +39,14 @@ td, th {
 	opacity: 0;
 	background: no-repeat center url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Ctext x='256' y='256'%3EPlease wait...%3C/text%3E%3C/svg%3E");
 	animation: fadein 0.5s ease-in 0.2s forwards;
+}
+
+/* Slight delay on "Please Wait" to reduce flicker */
+@keyframes fadein {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 0.5;
+	}
 }

--- a/context/app/static/extra.js
+++ b/context/app/static/extra.js
@@ -1,4 +1,4 @@
-$('body').on('click', '.nav-tabs a', function(e) {
+$('body').on('click', '.nav-tabs li a', function(e) {
     e.preventDefault();
     $(this).tab('show');
 });

--- a/context/app/vis/layout.py
+++ b/context/app/vis/layout.py
@@ -235,7 +235,6 @@ def _tabs(*names, help_button=False):
             target='_blank',
             className=css_classes
         ))
-        li_list.append(' ')
         li_list.append(html.A(
             ['Report Bug'], href='https://github.com/refinery-platform/'
             'heatmap-scatter-dash/issues/new',

--- a/context/app/vis/layout.py
+++ b/context/app/vis/layout.py
@@ -47,13 +47,13 @@ class VisLayout(VisBase, ResourceLoader):
             html.Div([
                 html.Div(
                     self._left_column(),
-                    className='col-md-6'),
+                    className='col-xs-6'),
                 html.Div(
                     self._right_column(
                         pc_options=pc_options,
                         conditions_options=conditions_options,
                         volcano_options=volcano_options),
-                    className='col-md-6')
+                    className='col-xs-6')
             ], className='row'),
             self._hidden_div()
         ], className='container-fluid')
@@ -67,7 +67,7 @@ class VisLayout(VisBase, ResourceLoader):
             html.Div([
                 html.Div([
                     html.Label(['gene'],
-                               className='col-sm-1 control-label'
+                               className='col-xs-1 control-label'
                                ),
                     html.Div([
                         dcc.Input(
@@ -75,15 +75,15 @@ class VisLayout(VisBase, ResourceLoader):
                             placeholder='search...',
                             type="text",
                             className='form-control')
-                    ], className='col-sm-5'),
+                    ], className='col-xs-5'),
                     html.Label(['scale'],
-                               className='col-sm-1 control-label'
+                               className='col-xs-1 control-label'
                                ),
                     dcc.Dropdown(
                         id='scale-select',
                         options=self.scale_options,
                         value='log',
-                        className='col-sm-5'
+                        className='col-xs-5'
                     )
                 ], className='form-group'),
             ], className='form-horizontal')
@@ -93,7 +93,7 @@ class VisLayout(VisBase, ResourceLoader):
         return [
             html.Br(),  # Top of tab was right against window top
 
-            _tabs('Conditions:', 'PCA', 'IDs'),
+            _tabs('Conditions:', 'PCA', 'IDs', help_button=True),
             html.Div([
                 self._scatter('pca', pc_options, active=True),
                 _iframe('ids')
@@ -108,16 +108,6 @@ class VisLayout(VisBase, ResourceLoader):
                 _iframe('table'),
                 _iframe('list')
             ], className='tab-content'),
-
-            html.Hr(),
-            html.Div([
-                html.A(['Help'], href='help', target='_blank'),
-                ' | ',
-                html.A(['Report Bug'],
-                       target='_blank',
-                       href='https://github.com/refinery-platform/'
-                            'heatmap-scatter-dash/issues/new')
-            ])
         ]
 
     def _hidden_div(self):
@@ -152,7 +142,7 @@ class VisLayout(VisBase, ResourceLoader):
         ]
         if volcano:
             dropdowns.append(
-                html.Label(['file'], className='col-sm-1 control-label')
+                html.Label(['file'], className='col-xs-1 control-label')
             )
             dropdowns.append(
                 dcc.Dropdown(
@@ -160,7 +150,7 @@ class VisLayout(VisBase, ResourceLoader):
                     options=self.file_options,
                     value=self.file_options[0]['value']
                     if self.file_options else None,
-                    className='col-sm-11'
+                    className='col-xs-11'
                 ))
             # TODO: scale selector for volcano?
         control_nodes = [
@@ -199,7 +189,7 @@ def _iframe(id):
     ], className='tab-pane', id=id)
 
 
-def _dropdown(id, options, axis, axis_index, full_width=False):
+def _dropdown(id, options, axis, axis_index):
     if options:
         value = options[axis_index]['value']
     else:
@@ -208,13 +198,13 @@ def _dropdown(id, options, axis, axis_index, full_width=False):
         [
             html.Label(
                 [axis],
-                className='col-sm-1 control-label'
+                className='col-xs-1 control-label'
             ),
             dcc.Dropdown(
                 id='scatter-{}-{}-axis-select'.format(id, axis),
                 options=options,
                 value=value,
-                className='col-sm-11' if full_width else 'col-sm-5'
+                className='col-xs-5'
             )
         ]
     )
@@ -228,13 +218,30 @@ def _class_from_index(i):
     return ''
 
 
-def _tabs(*names):
-    tabs = html.Ul([
+def _tabs(*names, help_button=False):
+    li_list = [
         html.Li([
             html.A([
                 name
             ], href='#' + name.lower())
         ], className=_class_from_index(index))
-        for (index, name) in enumerate(names)],
+        for (index, name) in enumerate(names)
+    ]
+
+    css_classes = 'btn btn-primary pull-right btn-sm'
+    if help_button:
+        li_list.append(html.A(
+            ['Help'], href='help',
+            target='_blank',
+            className=css_classes
+        ))
+        li_list.append(' ')
+        li_list.append(html.A(
+            ['Report Bug'], href='https://github.com/refinery-platform/'
+            'heatmap-scatter-dash/issues/new',
+            target='_blank',
+            className=css_classes
+        ))
+    tabs = html.Ul(li_list,
         className='nav nav-tabs')
     return tabs

--- a/context/app/vis/layout.py
+++ b/context/app/vis/layout.py
@@ -56,7 +56,7 @@ class VisLayout(VisBase, ResourceLoader):
                     className='col-md-6')
             ], className='row'),
             self._hidden_div()
-        ], className='container')
+        ], className='container-fluid')
 
     def _left_column(self):
         return [
@@ -171,7 +171,7 @@ class VisLayout(VisBase, ResourceLoader):
                 id='scatter-{}'.format(id),
                 style={
                     'height': '33vh',
-                    'width': '40vw'
+                    'width': '45vw'
                     # Shouldn't need to specify manually, but
                     # volcano was not getting the correct horizontal sizing...
                     # maybe because it's not on the screen at load time?

--- a/context/app/vis/layout.py
+++ b/context/app/vis/layout.py
@@ -242,5 +242,5 @@ def _tabs(*names, help_button=False):
             className=css_classes
         ))
     tabs = html.Ul(li_list,
-        className='nav nav-tabs')
+                   className='nav nav-tabs')
     return tabs


### PR DESCRIPTION
Lots of style tweaks:
- To allow more window sizes, change to `fluid`, and replace `sm` with `xs`
- Move the outlinks from the the bottom to the right of the first tabs: There's extra space here, and it makes them less likely to be lost off the bottom.