### PR TITLE
Mccalluc/guess count or diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v0.1.14](https://github.com/refinery-platform/heatmap-scatter-dash/tree/v0.1.14) (Aug 2, 2018)
+
+* app_runner_refinery sniffs files to determine if they are counts or differential expression.
+
+
 ## [v0.1.13](https://github.com/refinery-platform/heatmap-scatter-dash/tree/v0.1.13) (Jul 26, 2018)
 
 * If the body of the table has non-numeric columns, the value in the first

--- a/context/app/utils/vulcanize.py
+++ b/context/app/utils/vulcanize.py
@@ -1,7 +1,6 @@
 import re
 from math import log10
 
-
 LOG_FOLD_RE = r'\blog[^a-z]'
 P_VALUE_RE = r'p.*value'
 

--- a/context/app/utils/vulcanize.py
+++ b/context/app/utils/vulcanize.py
@@ -2,6 +2,10 @@ import re
 from math import log10
 
 
+LOG_FOLD_RE = r'\blog[^a-z]'
+P_VALUE_RE = r'p.*value'
+
+
 def vulcanize(dataframe):
     """
     Given a dataframe,
@@ -9,8 +13,8 @@ def vulcanize(dataframe):
     remove all other columns,
     and replace p-value with its negative log.
     """
-    log_fold_col = _pick_col(r'\blog[^a-z]', dataframe)
-    p_value_col = _pick_col(r'p.*value', dataframe)
+    log_fold_col = _pick_col(LOG_FOLD_RE, dataframe)
+    p_value_col = _pick_col(P_VALUE_RE, dataframe)
     log_p_value_col = '-log10({})'.format(p_value_col)
     dataframe[log_p_value_col] =\
         dataframe[p_value_col].apply(_neg_log)

--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -49,20 +49,13 @@ class RunnerArgs():
             assert type(self.api_prefix) == str
 
             data_directory = input_data['extra_directories'][0]
-
-            file_urls = input_data['file_relationships'][0]
-            diff_urls = input_data['file_relationships'][1]
-            meta_urls = []  # TODO: Not supported by Refinery
+            file_urls = input_data['file_relationships']
         else:
             data_directory = os.environ.get('DATA_DIR', '/tmp')
-
             file_urls = _split_envvar('FILE_URLS')
-            diff_urls = _split_envvar('DIFF_URLS')
-            meta_urls = _split_envvar('META_URLS')
         try:
             self.files = _download_files(file_urls, data_directory)
-            self.diffs = _download_files(diff_urls, data_directory)
-            self.metas = _download_files(meta_urls, data_directory)
+            # TODO: set self.diffs
         except OSError as e:
             raise Exception('Does {} exist?'.format(data_directory)) from e
 
@@ -144,8 +137,7 @@ def arg_parser():
                         help='If the specified file does not exist, '
                         'falls back to environment variables: '
                         'First, INPUT_JSON or INPUT_JSON_URL, '
-                        'and if neither of those exist, '
-                        'FILE_URLS, DIFF_URLS, META_URLS.')
+                        'and if neither of those exist, FILE_URLS.')
     parser.add_argument('--port', type=int, default=80)
     # During development, it's useful to be able to specify a high port.
     return parser

--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -61,8 +61,6 @@ class RunnerArgs():
             self.diffs = []
             for file in mystery_files:
                 df = dataframer.parse(file).data_frame
-                # TODO: This is reading and parsing the entire file...
-                # Could we try just the first n bytes?
                 file.seek(0)  # Reset cursor we can re-read the file.
                 if (_column_matches_re(df, P_VALUE_RE) and
                         _column_matches_re(df, LOG_FOLD_RE)):

--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -65,9 +65,9 @@ class RunnerArgs():
                 # Could we try just the first n bytes?
                 if (_column_matches_re(df, P_VALUE_RE) and
                         _column_matches_re(df, LOG_FOLD_RE)):
-                    self.diffs.append(file.name)
+                    self.diffs.append(file)
                 else:
-                    self.files.append(file.name)
+                    self.files.append(file)
         except OSError as e:
             raise Exception('Does {} exist?'.format(data_directory)) from e
 

--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -63,6 +63,7 @@ class RunnerArgs():
                 df = dataframer.parse(file).data_frame
                 # TODO: This is reading and parsing the entire file...
                 # Could we try just the first n bytes?
+                file.seek(0)  # Reset cursor we can re-read the file.
                 if (_column_matches_re(df, P_VALUE_RE) and
                         _column_matches_re(df, LOG_FOLD_RE)):
                     self.diffs.append(file)

--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -10,11 +10,11 @@ from tempfile import mkdtemp
 from urllib.parse import urlparse
 from warnings import warn
 
-from dataframer import dataframer
 import requests
+from dataframer import dataframer
 
 import app_runner
-from app.utils.vulcanize import P_VALUE_RE, LOG_FOLD_RE
+from app.utils.vulcanize import LOG_FOLD_RE, P_VALUE_RE
 
 
 class RunnerArgs():
@@ -65,7 +65,7 @@ class RunnerArgs():
                     # TODO: This is reading and parsing the entire file...
                     # Could we try just the first n bytes?
                     if (_column_matches_re(df, P_VALUE_RE) and
-                        _column_matches_re(df, LOG_FOLD_RE)):
+                            _column_matches_re(df, LOG_FOLD_RE)):
                         self.diffs.append(file)
                     else:
                         self.files.append(file)

--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -60,15 +60,14 @@ class RunnerArgs():
             self.files = []
             self.diffs = []
             for file in mystery_files:
-                with open(file, 'rb') as binary_stream:
-                    df = dataframer.parse(binary_stream)
-                    # TODO: This is reading and parsing the entire file...
-                    # Could we try just the first n bytes?
-                    if (_column_matches_re(df, P_VALUE_RE) and
-                            _column_matches_re(df, LOG_FOLD_RE)):
-                        self.diffs.append(file)
-                    else:
-                        self.files.append(file)
+                df = dataframer.parse(file).data_frame
+                # TODO: This is reading and parsing the entire file...
+                # Could we try just the first n bytes?
+                if (_column_matches_re(df, P_VALUE_RE) and
+                        _column_matches_re(df, LOG_FOLD_RE)):
+                    self.diffs.append(file.name)
+                else:
+                    self.files.append(file.name)
         except OSError as e:
             raise Exception('Does {} exist?'.format(data_directory)) from e
 
@@ -112,7 +111,7 @@ def _split_envvar(name):
 def _download_files(urls, data_dir):
     """
     Given a list of urls and a target directory,
-    download the files to the target, and return a list of filenames.
+    download the files to the target, and return a list of file handles.
     """
     files = []
 

--- a/context/tests/test_app_runner.py
+++ b/context/tests/test_app_runner.py
@@ -15,13 +15,19 @@ class TestAppRunnerRefinery(unittest.TestCase):
         with self.assertRaises(SystemExit):
             app_runner_refinery.arg_parser().parse_args()
 
-    @patch.object(app_runner_refinery, '_download_files')
     @patch.object(app_runner, 'init')
-    def test_with_input(self, mock_init, mock_download):
+    def test_with_input(self, mock_init):
         path = relative_path(__file__, '../../fixtures/good/input.json')
         refinery_args = app_runner_refinery.arg_parser().parse_args([
             '--input', path])
         runner_args = app_runner_refinery.RunnerArgs(refinery_args)
+        self.assertEqual(
+            runner_args.files,
+            ['/tmp/counts.csv', '/tmp/counts-copy.csv.gz', '/tmp/fake.gct'])
+        self.assertEqual(
+            runner_args.diffs,
+            ['/tmp/stats-with-genes-in-col-1.csv',
+             '/tmp/stats-with-genes-in-col-2.tsv'])
         app_runner.main(runner_args)
         mock_init.assert_called_once()
         mock_download.assert_called()

--- a/context/tests/test_app_runner.py
+++ b/context/tests/test_app_runner.py
@@ -22,15 +22,14 @@ class TestAppRunnerRefinery(unittest.TestCase):
             '--input', path])
         runner_args = app_runner_refinery.RunnerArgs(refinery_args)
         self.assertEqual(
-            runner_args.files,
+            [file.name for file in runner_args.files],
             ['/tmp/counts.csv', '/tmp/counts-copy.csv.gz', '/tmp/fake.gct'])
         self.assertEqual(
-            runner_args.diffs,
+            [diff.name for diff in runner_args.diffs],
             ['/tmp/stats-with-genes-in-col-1.csv',
              '/tmp/stats-with-genes-in-col-2.tsv'])
         app_runner.main(runner_args)
         mock_init.assert_called_once()
-        mock_download.assert_called()
 
 
 class TestAppRunner(unittest.TestCase):

--- a/fixtures/good/input.json
+++ b/fixtures/good/input.json
@@ -2,15 +2,11 @@
   "api_prefix": "/",
   "api_prefix NOTE": "Should actually be something like: /visualizations/container-name/",
   "file_relationships": [
-    [
-      "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/counts.csv",
-      "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/counts-copy.csv.gz",
-      "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.9/fixtures/good/data/fake.gct"
-    ],
-    [
-      "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/stats-with-genes-in-col-1.csv",
-      "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/stats-with-genes-in-col-2.tsv"
-    ]
+    "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/counts.csv",
+    "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/counts-copy.csv.gz",
+    "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.9/fixtures/good/data/fake.gct",
+    "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/stats-with-genes-in-col-1.csv",
+    "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/stats-with-genes-in-col-2.tsv"
   ],
   "extra_directories": [
     "/refinery-data/"

--- a/fixtures/good/input.json
+++ b/fixtures/good/input.json
@@ -9,7 +9,7 @@
     "https://raw.githubusercontent.com/refinery-platform/heatmap-scatter-dash/v0.1.5/fixtures/good/data/stats-with-genes-in-col-2.tsv"
   ],
   "extra_directories": [
-    "/refinery-data/"
+    "/tmp/"
   ],
   "node_info": {
     "some-refinery-uuid-1": {


### PR DESCRIPTION
This would let Refinery just pass in a flat list of files. Right now, this entails a whole redundant read of the file to determine what it is... Maybe app_runner_refinery could pass along dataframes, instead of handles, or maybe dataframer could just read the first portion of a file if all we want are the headers... but both of those routes might be premature optimizations?

(And, stepping back, is there anything to be said for forcing the users to be explicit about how different files should be used?)