### PR TITLE
If the fetch failed, there may not be a response to close

### DIFF
--- a/context/app_runner_refinery.py
+++ b/context/app_runner_refinery.py
@@ -140,7 +140,6 @@ def _download_files(urls, data_dir):
                     if chunk:
                         f.write(chunk)
             files.append(open(path, 'rb'))
-        finally:
             response.close()
     return files
 


### PR DESCRIPTION
I think this improves #189: We will now get a stack trace from the right location.

I'm not sure I'm really reproducing the original problem exactly, so leave #189 open and revisit in production at some point.