### PR TITLE
make metadata columns correspond to data columns. Fix #198

### DIFF
--- a/fixtures/good/data/metadata.csv
+++ b/fixtures/good/data/metadata.csv
@@ -1,3 +1,5 @@
 condition,meta1,meta2,meta3
 c1,1,-2,1
 c2,2,-1,10
+c3,1,-2,1
+c4,2,-1,10


### PR DESCRIPTION
This would only happen when metadata is supplied, which explains why we don't see it in production. Our fixture metadata had fewer condition rows than the data table had condition columns.

(Down the road, we might want friendlier validation if these rows and columns don't match, but I think it's best to wait until the metadata is actually getting some use before investing time in that.)